### PR TITLE
chore: fix scan QR code again when error

### DIFF
--- a/ios/Podfile.lock
+++ b/ios/Podfile.lock
@@ -10,7 +10,7 @@ PODS:
     - ExpoModulesCore
   - ExpoAsset (10.0.10):
     - ExpoModulesCore
-  - ExpoCamera (15.0.14):
+  - ExpoCamera (15.0.15):
     - ExpoModulesCore
     - ZXingObjC/OneD
     - ZXingObjC/PDF417
@@ -1753,7 +1753,7 @@ SPEC CHECKSUMS:
   EXImageLoader: ab589d67d6c5f2c33572afea9917304418566334
   Expo: 8b7948e45627e848c2d7b6be7cf5851a505aef19
   ExpoAsset: 323700f291684f110fb55f0d4022a3362ea9f875
-  ExpoCamera: a5d000b22cd7dfd2c5904ed960e549de42c96da0
+  ExpoCamera: 470eeb1c0170f5a5b96c7179b0285f0ef5e9e161
   ExpoFileSystem: 80bfe850b1f9922c16905822ecbf97acd711dc51
   ExpoImage: cbe7617b4e0e7ba064cc4caa51bfc96262e51ef3
   ExpoImagePicker: 12a420923383ae38dccb069847218f27a3b87816

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "decimal.js": "^10.4.3",
     "ethers": "^6.10.0",
     "expo": "51",
-    "expo-camera": "~15.0.13",
+    "expo-camera": "^15.0.15",
     "expo-image": "~1.12.13",
     "expo-image-picker": "~15.0.7",
     "expo-localization": "~15.0.3",

--- a/packages/ui-new/pages/ExternalInputHandler/useQRCodeScan.tsx
+++ b/packages/ui-new/pages/ExternalInputHandler/useQRCodeScan.tsx
@@ -1,16 +1,14 @@
 import { launchImageLibraryAsync } from 'expo-image-picker';
-import { useCallback, useMemo, useState } from 'react';
-import type { StyleProp, ViewStyle } from 'react-native';
-import { CameraView, useCameraPermissions, type BarcodeScanningResult, Camera } from 'expo-camera';
+import { useCallback, useState } from 'react';
+import { useCameraPermissions, type BarcodeScanningResult, Camera } from 'expo-camera';
 
 interface Params {
-  style: StyleProp<ViewStyle>;
   onSuccess: (data: string) => void;
   onFailed: () => void;
   isParsingRef: React.MutableRefObject<boolean>;
 }
 
-const useQRCodeScan = ({ style, onSuccess, onFailed, isParsingRef }: Params) => {
+const useQRCodeScan = ({ onSuccess, onFailed, isParsingRef }: Params) => {
   const [hasPermission, requestPermission] = useCameraPermissions();
   const [hasRejectCameraPermission, setHasRejectCameraPermission] = useState(false);
 
@@ -64,17 +62,12 @@ const useQRCodeScan = ({ style, onSuccess, onFailed, isParsingRef }: Params) => 
     }
   }, [hasPermission]);
 
-  const CameraComponent = useMemo(
-    () => <CameraView facing="back" style={style} barcodeScannerSettings={{ barcodeTypes: ['qr'] }} onBarcodeScanned={handleCodeScan} />,
-    [style, handleCodeScan],
-  );
-
   return {
     checkCameraPermission,
     hasRejectCameraPermission,
     hasCameraPermission: hasPermission?.granted,
     pickImage,
-    Camera: CameraComponent,
+    handleCodeScan,
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -8701,14 +8701,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"expo-camera@npm:~15.0.13":
-  version: 15.0.14
-  resolution: "expo-camera@npm:15.0.14"
+"expo-camera@npm:^15.0.15":
+  version: 15.0.15
+  resolution: "expo-camera@npm:15.0.15"
   dependencies:
     invariant: ^2.2.4
   peerDependencies:
     expo: "*"
-  checksum: 97dba413893b47de490dc6716a507f175d68b58be38d0f62037d08d7b0af02d2ad048916570f275d23f0c765883b45a0cc868f58bec277eb88f3064912ad0675
+  checksum: 5cdd04cef971770f92f665f6389c12f9b4d732db8b25131f44d7585ffb20273fa91d376d4a15355c1aefe70bf9e908ff25e24428a9f3228c1e79f48af1f7a846
   languageName: node
   linkType: hard
 
@@ -16924,7 +16924,7 @@ __metadata:
     eslint: ^8.56.0
     ethers: ^6.10.0
     expo: 51
-    expo-camera: ~15.0.13
+    expo-camera: ^15.0.15
     expo-image: ~1.12.13
     expo-image-picker: ~15.0.7
     expo-localization: ~15.0.3


### PR DESCRIPTION
- Update the expo-camera to support  `pausePreview` and `resumePreview` method
- Update useQRCodeScan hook
